### PR TITLE
Okta Connection Error Handling

### DIFF
--- a/src/bfg/modules/http/okta/module.py
+++ b/src/bfg/modules/http/okta/module.py
@@ -203,7 +203,7 @@ class Module(HTTPModule):
                     allow_redirects=False,
                     proxies=self.proxies)
 
-        except ConnectionError or TimeOut:
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             return dict(
                 outcome=-1,
                 username=username,

--- a/src/bfg/modules/http/okta/module.py
+++ b/src/bfg/modules/http/okta/module.py
@@ -194,14 +194,22 @@ class Module(HTTPModule):
         # Update headers again. Referer header should match the cookies_url
         headers['referer'] = cookies_url
     
-        # make the request
-        resp = session.post(self.url,
-                json=data,
-                headers=headers,
-                verify=self.verify_ssl,
-                allow_redirects=False,
-                proxies=self.proxies)
+        try:
+            # make the request
+            resp = session.post(self.url,
+                    json=data,
+                    headers=headers,
+                    verify=self.verify_ssl,
+                    allow_redirects=False,
+                    proxies=self.proxies)
 
+        except ConnectionError or TimeOut:
+            return dict(
+                outcome=-1,
+                username=username,
+                password=password,
+                events=['Connection Error or Timeout'])
+        
         # ===================================
         # CHECK FOR SUCCESSFUL AUTHENTICATION
         # ===================================


### PR DESCRIPTION
In the Okta module, credentials were being counted as valid when connections timed out or failed. 

Added a try/except to the authentication request to account for bad connections and mark the credentials as CRED_FAILED (-1). 