### PR TITLE
Fixing GlobalProtect module errors

### DIFF
--- a/src/bfg/modules/http/global_protect/module.py
+++ b/src/bfg/modules/http/global_protect/module.py
@@ -102,8 +102,8 @@ class Module(HTTPModule):
         self.server = groups['server']
 
         # Global Protect requires a specific Content-Type header
-        if not 'Content-Type' in headers:
-            headers['Content-Type'] = 'application/x-www-form-urlencoded'
+        if not 'Content-Type' in self.headers:
+            self.headers['Content-Type'] = 'application/x-www-form-urlencoded'
 
         sess = requests.Session()
 

--- a/src/bfg/shortcuts/http.py
+++ b/src/bfg/shortcuts/http.py
@@ -10,7 +10,7 @@ from bfg.breakers import (
     LockoutErrorBreakerProfile)
 from functools import wraps
 from random import randint
-from inspect import getargspec
+from inspect import getfullargspec
 import pdb
 
 warnings.filterwarnings('ignore')


### PR DESCRIPTION
The global_protect module was throwing some errors. 

Updated an import in http.py and the header bit in the global_protect module.py. This worked for me in making the module run successfully. 